### PR TITLE
feat (SC-310): auto read checked off by default

### DIFF
--- a/epyqlib/nvview.ui
+++ b/epyqlib/nvview.ui
@@ -198,7 +198,7 @@
           <string>Auto Read</string>
          </property>
          <property name="checked">
-          <bool>true</bool>
+          <bool>false</bool>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Have the “Auto Read” checkbox on EPyQ parameters tab be checked off by default.

[SC-310](https://epcpower.atlassian.net/browse/SC-310)