### PR TITLE
chore(SC-2522): Update pyelftools to be compatible with dgt eabi parser

### DIFF
--- a/epyqlib/cmemoryparser.py
+++ b/epyqlib/cmemoryparser.py
@@ -860,14 +860,14 @@ def process_file(filename):
         debug_line_sec=debug_sections.get(".debug_line", None),
         debug_pubtypes_sec=debug_sections.get(".pubtypes_sec", None),
         debug_pubnames_sec=debug_sections.get(".pubnames_sec", None),
-        debug_addr_sec=debug_sections.get('.debug_addr', None),
-        debug_str_offsets_sec=debug_sections.get('.debug_str_offsets', None),
-        debug_line_str_sec=debug_sections.get('.debug_line_str', None),
-        debug_loclists_sec=debug_sections.get('.debug_loclists', None),
-        debug_rnglists_sec=debug_sections.get('.debug_rnglists', None),
-        debug_sup_sec=debug_sections.get('.debug_sup', None),
-        gnu_debugaltlink_sec=debug_sections.get('.gnu_debugaltlink', None),
-        debug_types_sec=debug_sections.get('.debug_types', None),
+        debug_addr_sec=debug_sections.get(".debug_addr", None),
+        debug_str_offsets_sec=debug_sections.get(".debug_str_offsets", None),
+        debug_line_str_sec=debug_sections.get(".debug_line_str", None),
+        debug_loclists_sec=debug_sections.get(".debug_loclists", None),
+        debug_rnglists_sec=debug_sections.get(".debug_rnglists", None),
+        debug_sup_sec=debug_sections.get(".debug_sup", None),
+        gnu_debugaltlink_sec=debug_sections.get(".gnu_debugaltlink", None),
+        debug_types_sec=debug_sections.get(".debug_types", None),
     )
 
     objects = collections.OrderedDict(

--- a/epyqlib/cmemoryparser.py
+++ b/epyqlib/cmemoryparser.py
@@ -18,7 +18,7 @@ import sys
 sys.path[0:0] = [".", ".."]
 
 import collections
-from elftools.dwarf.dwarf_expr import GenericExprVisitor
+from elftools.dwarf.dwarf_expr import DWARFExprParser
 from elftools.dwarf.dwarfinfo import DebugSectionDescriptor
 from elftools.dwarf.descriptions import describe_attr_value
 import elftools.common.exceptions
@@ -88,10 +88,10 @@ def bytearray_to_bits(data):
 
 
 def process_expression(expression, dwarf_info):
-    generic_expression_visitor = GenericExprVisitor(dwarf_info.structs)
-    generic_expression_visitor.process_expr(expression)
-    (result,) = generic_expression_visitor._cur_args
-    return result
+    raise NotImplementedError
+    generic_expression_visitor = DWARFExprParser(dwarf_info.structs)
+    parsed = generic_expression_visitor.parse_expr(expression)
+    return parsed[0].args[0]
 
 
 @attr.s
@@ -860,6 +860,14 @@ def process_file(filename):
         debug_line_sec=debug_sections.get(".debug_line", None),
         debug_pubtypes_sec=debug_sections.get(".pubtypes_sec", None),
         debug_pubnames_sec=debug_sections.get(".pubnames_sec", None),
+        debug_addr_sec=debug_sections.get('.debug_addr', None),
+        debug_str_offsets_sec=debug_sections.get('.debug_str_offsets', None),
+        debug_line_str_sec=debug_sections.get('.debug_line_str', None),
+        debug_loclists_sec=debug_sections.get('.debug_loclists', None),
+        debug_rnglists_sec=debug_sections.get('.debug_rnglists', None),
+        debug_sup_sec=debug_sections.get('.debug_sup', None),
+        gnu_debugaltlink_sec=debug_sections.get('.gnu_debugaltlink', None),
+        debug_types_sec=debug_sections.get('.debug_types', None),
     )
 
     objects = collections.OrderedDict(

--- a/poetry.lock
+++ b/poetry.lock
@@ -1199,7 +1199,7 @@ files = [
 
 [[package]]
 name = "pyelftools"
-version = "0.25"
+version = "0.30"
 description = "Library for analyzing ELF files and DWARF debugging information"
 optional = false
 python-versions = "*"
@@ -1209,8 +1209,8 @@ develop = false
 [package.source]
 type = "git"
 url = "https://github.com/eliben/pyelftools"
-reference = "27941c50fef8cff8ef991419511664154c8cdf52"
-resolved_reference = "27941c50fef8cff8ef991419511664154c8cdf52"
+reference = "a612ffead684f67674a109b60b0dc8f20770308a"
+resolved_reference = "a612ffead684f67674a109b60b0dc8f20770308a"
 
 [[package]]
 name = "pygments"
@@ -2271,4 +2271,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<3.11"
-content-hash = "c7a8fd6e4b221f6ca1854d4bd68ef8b4d6b7ad6b4e92d996fd82eea07a7d0d71"
+content-hash = "45852f6da19dba1f95b7fa2da743a6329541b1e4a3413d79f232563b573e35f0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ marshmallow = "2.16.3"
 natsort = "5.5.0"
 paho-mqtt = "1.4.0"
 Pint = "0.19.2"
-pyelftools = { git = "https://github.com/eliben/pyelftools", rev = "27941c50fef8cff8ef991419511664154c8cdf52" }
+pyelftools = { git = "https://github.com/eliben/pyelftools", rev = "a612ffead684f67674a109b60b0dc8f20770308a" } # Supports Dwarf4 Type Signature Traversal
 PyQt5 = ">=5.13.0"
 qt5reactor = "0.6.3"
 python-dateutil = "^2.8.2"


### PR DESCRIPTION
## Jira Story
https://epcpower.atlassian.net/browse/SC-2522

## About
To be able to include the parse_eabi_file.py from dgt, the pyelftools has to be updated to same version. Since epyq symbol parsing does not work anyway, the cmemoryparser is fixed just enough that it does not cause interpreter errors when launching it. The cmemoryparser or epyq datalogger will not be used in the foreseeable future in M

## Associated Pull Requests

* [ ] https://github.com/epcpower/m-bcu/pull/19
* [ ] https://github.com/epcpower/m-tcu/pull/96

## Reproduction Steps

## Validation
