### PR TITLE
fix(SC-2603): Fix error when drag&dropping in pm

### DIFF
--- a/epyqlib/attrsmodel.py
+++ b/epyqlib/attrsmodel.py
@@ -1492,8 +1492,13 @@ class Model:
                     else:
                         new_parent.append_child(new_child)
                 else:
-                    new_row = new_parent.row_of_child(node_to_insert_before)
-                    new_parent.insert_child(new_row, new_child)
+                    if isinstance(new_child, list):
+                        for c in new_child:
+                            new_row = new_parent.row_of_child(node_to_insert_before)
+                            new_parent.insert_child(new_row, c)
+                    else:
+                        new_row = new_parent.row_of_child(node_to_insert_before)
+                        new_parent.insert_child(new_row, new_child)
 
         # Always returning False so that Qt won't do anything...  like
         # thinking it knows which row of items to delete to finish the

--- a/epyqlib/utils/qt.py
+++ b/epyqlib/utils/qt.py
@@ -949,7 +949,7 @@ def pyqtify(name=None, property_decorator=lambda: property):
                 raise AttributeError(
                     "'{class_name}' object has no attribute '{name}'".format(
                         class_name=type(self).__name__,
-                        attribute=name,
+                        name=name,
                     )
                 )
 


### PR DESCRIPTION
## Jira Story
[SC-2603](https://epcpower.atlassian.net/browse/SC-2603)

## About
Error was raised if an object that generated a list of child objects was drag&dropped between already existing lines in pm

## Associated Pull Requests

* [ ] _
* [ ] _

## Reproduction Steps

## Validation


[SC-2603]: https://epcpower.atlassian.net/browse/SC-2603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ